### PR TITLE
Python 3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - 2.7
   - 3.5
 matrix:
- fast_finish: true
+  fast_finish: true
   include:
   - python: 2.7
     env: DJANGO_VERSION=">=1.7, < 1.8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,7 @@ python:
   - 2.7
   - 3.5
 matrix:
-  allow_failures:
-  - python: 3.5
-    env: DJANGO_VERSION=">=1.8, < 1.9"
-  - python: 3.5
-    env: DJANGO_VERSION=">=1.9, < 1.10"
-  fast_finish: true
+ fast_finish: true
   include:
   - python: 2.7
     env: DJANGO_VERSION=">=1.7, < 1.8"

--- a/build-requirements.pip
+++ b/build-requirements.pip
@@ -1,2 +1,3 @@
 gitversion
 beautifulsoup4
+six

--- a/nuit/templatetags/nuit.py
+++ b/nuit/templatetags/nuit.py
@@ -8,7 +8,10 @@ from django.template.loader_tags import do_extends, ExtendsNode
 from django.template.defaultfilters import slugify
 from django.utils.html import format_html
 from ast import literal_eval
-from urlparse import urlparse
+try:
+    from urlparse import urlparse
+except ImportError:
+    from urllib.parse import urlparse
 
 from ..utils import user_can_see_view
 

--- a/nuit/templatetags/nuit.py
+++ b/nuit/templatetags/nuit.py
@@ -8,11 +8,8 @@ from django.template.loader_tags import do_extends, ExtendsNode
 from django.template.defaultfilters import slugify
 from django.utils.html import format_html
 from ast import literal_eval
-try:
-    from urlparse import urlparse
-except ImportError:
-    from urllib.parse import urlparse
-
+from six.moves.urllib.parse import urlparse
+from six import iteritems as _iteritems
 from ..utils import user_can_see_view
 
 # pylint: disable=C0103
@@ -47,19 +44,6 @@ def set_active_menu(active_menu):
     to highlight the correct menu item.
     '''
     return format_html("<span style='display: none' class='nuit-active-menu'>{}</span>", active_menu)
-
-
-def _iteritems(kwargs):
-    '''
-    A compatibility layer between Python 2 and 3
-    >>> d = {"a": "b", "c": "d"}
-    >>> _iteritems(d)
-    [("a", "b"), ("c", "d")]
-    '''
-    try:
-        return kwargs.iteritems()
-    except AttributeError:
-        return kwargs.items()
 
 
 class ExtendNode(ExtendsNode):

--- a/nuit/templatetags/nuit.py
+++ b/nuit/templatetags/nuit.py
@@ -49,6 +49,19 @@ def set_active_menu(active_menu):
     return format_html("<span style='display: none' class='nuit-active-menu'>{}</span>", active_menu)
 
 
+def _iteritems(kwargs):
+    '''
+    A compatibility layer between Python 2 and 3
+    >>> d = {"a": "b", "c": "d"}
+    >>> _iteritems(d)
+    [("a", "b"), ("c", "d")]
+    '''
+    try:
+        return kwargs.iteritems()
+    except AttributeError:
+        return kwargs.items()
+
+
 class ExtendNode(ExtendsNode):
     '''
     Template node that extends another template with additional variables.
@@ -56,13 +69,13 @@ class ExtendNode(ExtendsNode):
 
     def __init__(self, node, kwargs):
         super(ExtendNode, self).__init__(node.nodelist, node.parent_name, node.template_dirs)
-        self.kwargs = dict(("nuit_%s" % key, value) for key, value in kwargs.iteritems())
+        self.kwargs = dict(("nuit_%s" % key, value) for key, value in _iteritems(kwargs))
 
     def __repr__(self):
         return '<ExtendNode: extends %s with args: %r>' % (super(ExtendNode, self).__repr__(), self.kwargs)
 
     def render(self, context):
-        kwargs = dict((key, value.resolve(context)) for key, value in self.kwargs.iteritems() if key not in context)
+        kwargs = dict((key, value.resolve(context)) for key, value in _iteritems(self.kwargs) if key not in context)
         context.update(kwargs)
         try:
             return super(ExtendNode, self).render(context)
@@ -142,7 +155,7 @@ def menu_section(parser, token):
         kwargs[before] = after
     nodelist = parser.parse(('end_menu_section',))
     parser.delete_first_token()
-    kwargs = dict((key, parser.compile_filter(value)) for key, value in kwargs.iteritems())
+    kwargs = dict((key, parser.compile_filter(value)) for key, value in _iteritems(kwargs))
     return MenuSectionNode(nodelist, **kwargs)
 
 
@@ -176,7 +189,7 @@ def app_menu(parser, token):
         kwargs[before] = after
     nodelist = parser.parse(('end_app_menu',))
     parser.delete_first_token()
-    kwargs = dict((key, parser.compile_filter(value)) for key, value in kwargs.iteritems())
+    kwargs = dict((key, parser.compile_filter(value)) for key, value in _iteritems(kwargs))
     return AppMenuNode(nodelist, **kwargs)
 
 

--- a/nuit/tests/test_main.py
+++ b/nuit/tests/test_main.py
@@ -20,6 +20,8 @@ from . import views
 from django.db import models
 
 import string
+from six import iteritems
+
 
 def setup_view(view, request, *args, **kwargs):
     """Mimic as_view() returned callable, but returns view instance.
@@ -269,7 +271,7 @@ class NuitTemplateTags(TestCase):
             if data['header']:
                 self.assertEqual(1, len(section.findAll('h5')))
                 self.assertEqual(data['header'], section.find('h5').text)
-            for key, value in data['attrs'].iteritems():
+            for key, value in iteritems(data['attrs']):
                 self.assertEqual(value, section.attrs[key])
 
     def test_app_menu(self):

--- a/nuit/utils.py
+++ b/nuit/utils.py
@@ -2,6 +2,7 @@
 
 from django.core.exceptions import PermissionDenied
 import six
+import inspect
 
 
 def _closure(fn):
@@ -17,7 +18,7 @@ def has_closure(fn):
 
 
 def has_code(fn):
-    return hasattr(fn, 'func_code') or hasattr(fn, '__code__')
+    return inspect.isfunction(fn)
 
 
 def get_callable_cells(function):

--- a/nuit/utils.py
+++ b/nuit/utils.py
@@ -41,9 +41,9 @@ def get_callable_cells(function):
             # Class-based view does not have a .func_closure attribute.
             # Instead, we want to look for decorators on the dispatch method.
             # We can also look for decorators on a "get" method, if one exists.
-            if hasattr(closure.cell_contents, 'dispatch'):
+            if hasattr(closure.cell_contents, 'dispatch') and inspect.ismethod(closure.cell_contents.dispatch):
                 callables.extend(get_callable_cells(_func(closure.cell_contents.dispatch)))
-                if hasattr(closure.cell_contents, 'get'):
+                if hasattr(closure.cell_contents, 'get') and inspect.ismethod(closure.cell_contents.get):
                     callables.extend(get_callable_cells(_func(closure.cell_contents.get)))
             elif has_closure(closure.cell_contents) and _closure(closure.cell_contents):
                 callables.extend(get_callable_cells(closure.cell_contents))

--- a/nuit/utils.py
+++ b/nuit/utils.py
@@ -13,8 +13,22 @@ def _closure(fn):
         return fn.__closure__
 
 
+def _code(fn):
+    '''
+    Python 2 and Python 3 compatibility function
+    '''
+    try:
+        return fn.func_code
+    except AttributeError:
+        return fn.__code__
+
+
 def has_closure(fn):
     return hasattr(fn, 'func_closure') or hasattr(fn, '__closure__')
+
+
+def has_code(fn):
+    return hasattr(fn, 'func_code') or hasattr(fn, '__code__')
 
 
 def get_callable_cells(function):
@@ -48,7 +62,7 @@ def get_class_based_views(callable_cells):
     '''Find class based views for a set of cells.'''
     for cell in callable_cells:
         if has_closure(cell) and _closure(cell):
-            closure_dict = dict(zip(cell.func_code.co_freevars, _closure(cell)))
+            closure_dict = dict(zip(_code(cell).co_freevars, _closure(cell)))
             if 'cls' in closure_dict:
                 klass = closure_dict['cls'].cell_contents
                 if hasattr(klass, 'dispatch'):
@@ -79,9 +93,9 @@ def get_user_tests(function):
     callable_cells = get_callable_cells(function)
     return [
         x for x in callable_cells
-        if getattr(x, 'func_code', None) and (
-            x.func_code.co_varnames[0] in ["user", "u"] or
-            (len(x.func_code.co_varnames) > 1 and x.func_code.co_varnames[0] in ['self', 'cls'] and x.func_code.co_varnames[1] in ['u', 'user'])
+        if has_code(x) and (
+            _code(x).co_varnames[0] in ["user", "u"] or
+            (len(_code(x).co_varnames) > 1 and _code(x).co_varnames[0] in ['self', 'cls'] and _code(x).co_varnames[1] in ['u', 'user'])
         )
     ] + list(get_cbv_dispatch_tests(callable_cells))
 
@@ -90,8 +104,8 @@ def test_view(test, urlconf, user):
     '''
     Run a view test. Add in *args, **kwargs if appropriate.
     '''
-    args = [] if 'args' not in test.func_code.co_varnames else urlconf.args
-    kwargs = {} if 'kwargs' not in test.func_code.co_varnames else urlconf.kwargs
+    args = [] if 'args' not in _code(test).co_varnames else urlconf.args
+    kwargs = {} if 'kwargs' not in _code(test).co_varnames else urlconf.kwargs
     return test(user, *args, **kwargs)
 
 

--- a/nuit/utils.py
+++ b/nuit/utils.py
@@ -70,6 +70,7 @@ def get_cbv_dispatch_tests(callable_cells):
             return True
         yield test_func
 
+
 def get_user_tests(function):
     '''
     Get a list of callable cells attached to this function that have the first
@@ -84,6 +85,7 @@ def get_user_tests(function):
         )
     ] + list(get_cbv_dispatch_tests(callable_cells))
 
+
 def test_view(test, urlconf, user):
     '''
     Run a view test. Add in *args, **kwargs if appropriate.
@@ -91,6 +93,7 @@ def test_view(test, urlconf, user):
     args = [] if 'args' not in test.func_code.co_varnames else urlconf.args
     kwargs = {} if 'kwargs' not in test.func_code.co_varnames else urlconf.kwargs
     return test(user, *args, **kwargs)
+
 
 def user_can_see_view(view, user):
     '''

--- a/nuit/utils.py
+++ b/nuit/utils.py
@@ -13,6 +13,10 @@ def _code(fn):
     return six.get_function_code(fn)
 
 
+def _func(fn):
+    return six.get_method_function(fn)
+
+
 def has_closure(fn):
     return hasattr(fn, 'func_closure') or hasattr(fn, '__closure__')
 
@@ -38,9 +42,9 @@ def get_callable_cells(function):
             # Instead, we want to look for decorators on the dispatch method.
             # We can also look for decorators on a "get" method, if one exists.
             if hasattr(closure.cell_contents, 'dispatch'):
-                callables.extend(get_callable_cells(closure.cell_contents.dispatch.__func__))
+                callables.extend(get_callable_cells(_func(closure.cell_contents.dispatch)))
                 if hasattr(closure.cell_contents, 'get'):
-                    callables.extend(get_callable_cells(closure.cell_contents.get.__func__))
+                    callables.extend(get_callable_cells(_func(closure.cell_contents.get)))
             elif has_closure(closure.cell_contents) and _closure(closure.cell_contents):
                 callables.extend(get_callable_cells(closure.cell_contents))
             else:

--- a/nuit/utils.py
+++ b/nuit/utils.py
@@ -1,26 +1,15 @@
 '''Utils.'''
 
 from django.core.exceptions import PermissionDenied
+import six
 
 
 def _closure(fn):
-    '''
-    Python 2 and Python 3 compatibility function
-    '''
-    try:
-        return fn.func_closure
-    except AttributeError:
-        return fn.__closure__
+    return six.get_function_closure(fn)
 
 
 def _code(fn):
-    '''
-    Python 2 and Python 3 compatibility function
-    '''
-    try:
-        return fn.func_code
-    except AttributeError:
-        return fn.__code__
+    return six.get_function_code(fn)
 
 
 def has_closure(fn):

--- a/nuit/views.py
+++ b/nuit/views.py
@@ -1,5 +1,6 @@
 from django.views.generic import ListView
 from django.db.models import Q
+from six import string_types
 
 class SearchableListView(ListView):
     '''
@@ -32,7 +33,7 @@ class SearchableListView(ListView):
         query = Q()
         for field in self.search_fields:
             lookup = 'icontains'
-            if not isinstance(field, basestring):
+            if not isinstance(field, string_types):
                 field, lookup = field
             query = query | Q(**{'%s__%s' % (field, lookup): search_term})
         return queryset.filter(query)

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
         'django-autoconfig',
         'django-bourbon',
         'django-pipeline >= 1.6.0',
+        'six'
     ],
     include_package_data = True,
     test_suite           = 'setuptest.setuptest.SetupTestSuite',


### PR DESCRIPTION
Python 3 got renamed `urlparse` module to `urllib.parse`, due to that, whole package does not work on Python 3. 